### PR TITLE
Create collect_corrected.nf

### DIFF
--- a/modules/local/collect_corrected.nf
+++ b/modules/local/collect_corrected.nf
@@ -1,0 +1,28 @@
+process COLLECT_CORRECTED {
+    tag "collect"
+    label 'process_medium'
+    publishDir "${params.outdir}/joint", mode: 'copy'
+
+    input:
+    path p1_files   // 所有子样本的 P1_corrected 文件列表
+    path p2_files   // 所有子样本的 P2_corrected 文件列表
+    path s_files    // 所有子样本的 S_corrected 文件列表
+
+    output:
+    path "all_corrected_R1.fastq.gz", emit: r1
+    path "all_corrected_R2.fastq.gz", emit: r2
+    path "all_corrected_S.fastq.gz",  emit: s
+    path "versions.yml", emit: versions
+
+    script:
+    """
+    cat ${p1_files.join(' ')} > all_corrected_R1.fastq.gz
+    cat ${p2_files.join(' ')} > all_corrected_R2.fastq.gz
+    cat ${s_files.join(' ')}  > all_corrected_S.fastq.gz
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        script: "collect_corrected.nf"
+    END_VERSIONS
+    """
+}


### PR DESCRIPTION
这一部分是为了收集并合并校正 reads，不然子样本组装阶段（SPADES）为每个子样本生成三组校正 reads，分布在不同的任务输出目录中，无法直接用于联合组装。

<!--
# nf-core/scgs pull request

Many thanks for contributing to nf-core/scgs!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/scgs/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scgs/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/scgs _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
